### PR TITLE
libusb set configuration only when needed; fixes #2

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -50,7 +50,9 @@ pub fn open_device(context: &mut Context, vid: u16, pid: u16) -> Result<DeviceHa
                                 _ => continue
                             };
 
-                            handle.set_active_configuration(config.number())?;
+                            if handle.active_configuration()? != config.number() {
+                                handle.set_active_configuration(config.number())?;
+                            }
                             handle.claim_interface(usb_int.interface_number())?;
                         }
                     }


### PR DESCRIPTION
see yubikey-personalization implementation using libusb-1.0 [1]
[1] https://github.com/Yubico/yubikey-personalization/blob/master/ykcore/ykcore_libusb-1.0.c#L212-L216

The `libusb_set_configuration` call is optional and I've seen people [suggesting removing the call](https://github.com/pyusb/pyusb/issues/76).

This PR solves #2 for both the example HMAC-SHA1 and my project.