### PR TITLE
release device after use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ impl Yubico {
 
                 manager::write_frame(&mut handle, &d)?;
                 manager::wait(&mut handle, |f| !f.contains(Flags::SLOT_WRITE_FLAG), &mut buf)?;
+                manager::close_device(handle)?;
 
                 Ok(())
             },
@@ -102,6 +103,7 @@ impl Yubico {
                 // Read the response.
                 let mut response = [0; 36];
                 manager::read_response(&mut handle, &mut response)?;
+                manager::close_device(handle)?;
 
                 // Check response.
                 if crc16(&response[..6]) != CRC_RESIDUAL_OK {
@@ -142,6 +144,7 @@ impl Yubico {
                 // Read the response.
                 let mut response = [0; 36];
                 manager::read_response(&mut handle, &mut response)?;
+                manager::close_device(handle)?;
 
                 // Check response.
                 if crc16(&response[..22]) != CRC_RESIDUAL_OK {
@@ -177,6 +180,7 @@ impl Yubico {
                 manager::wait(&mut handle, |f| !f.contains(manager::Flags::SLOT_WRITE_FLAG), &mut buf)?;
                 manager::write_frame(&mut handle, &d)?;
                 manager::read_response(&mut handle, &mut response)?;
+                manager::close_device(handle)?;
 
                 // Check response.
                 if crc16(&response[..18]) != CRC_RESIDUAL_OK {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -67,6 +67,12 @@ pub fn open_device(context: &mut Context, vid: u16, pid: u16) -> Result<DeviceHa
     Err(YubicoError::DeviceNotFound)
 }
 
+pub fn close_device(mut handle: DeviceHandle) -> Result<(), YubicoError> {
+    handle.release_interface(0)?;
+    handle.attach_kernel_driver(0)?;
+    Ok(())
+}
+
 pub fn wait<F: Fn(Flags) -> bool>(handle: &mut DeviceHandle, f: F, buf: &mut [u8]) -> Result<(), YubicoError>  {
     loop {
         read(handle, buf)?;


### PR DESCRIPTION
see
[1] https://github.com/Yubico/yubikey-personalization/blob/fa5cf5ac18ca4419c9274717b89ed1f1f482ba30/ykcore/ykcore_libusb-1.0.c#L82
[2] https://github.com/Yubico/yubikey-personalization/blob/fa5cf5ac18ca4419c9274717b89ed1f1f482ba30/ykcore/ykcore_libusb-1.0.c#L127
[3] https://github.com/Yubico/yubikey-personalization/blob/fa5cf5ac18ca4419c9274717b89ed1f1f482ba30/ykcore/ykcore_libusb-1.0.c#L225-L230

Without this patch, I cannot use Yubico OTP in slot 1 unless I unplug & re-plug the key.