### PR TITLE
replace libusb with rusb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 [dependencies]
 rand = "0.7"
 bitflags = "1.2"
-libusb = "0.3"
+rusb = "0.6.5"
 structure = "0.1"
 
 aes-soft = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate libusb;
+extern crate rusb;
 
 #[macro_use] extern crate structure;
 
@@ -27,7 +27,7 @@ use sec::{CRC_RESIDUAL_OK, crc16};
 use manager::{Frame, Flags};
 use config::{Config, Slot};
 use yubicoerror::YubicoError;
-use libusb::{Context};
+use rusb::{Context, UsbContext};
 
 const VENDOR_ID: u16 = 0x1050;
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use std::{thread, slice};
 use sec::{crc16};
 use yubicoerror::YubicoError;
-use libusb::{request_type, Direction, RequestType, Recipient, Context, DeviceHandle};
+use rusb::{request_type, Direction, RequestType, Recipient, Context, DeviceHandle, UsbContext};
 
 const DATA_SIZE: usize = 64;
 const HID_GET_REPORT: u8 = 0x01;
@@ -17,7 +17,7 @@ bitflags! {
     }
 }
 
-pub fn open_device(context: &mut Context, vid: u16, pid: u16) -> Result<DeviceHandle, YubicoError> {
+pub fn open_device(context: &mut Context, vid: u16, pid: u16) -> Result<DeviceHandle<Context>, YubicoError> {
     let devices = match context.devices() {
         Ok(device) => device,
         Err(_) => {
@@ -72,18 +72,18 @@ pub fn open_device(context: &mut Context, vid: u16, pid: u16) -> Result<DeviceHa
 }
 
 #[cfg(target_os = "macos")]
-pub fn close_device(_handle: DeviceHandle) -> Result<(), YubicoError> {
+pub fn close_device(_handle: DeviceHandle<Context>) -> Result<(), YubicoError> {
     Ok(())
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn close_device(mut handle: DeviceHandle) -> Result<(), YubicoError> {
+pub fn close_device(mut handle: DeviceHandle<Context>) -> Result<(), YubicoError> {
     handle.release_interface(0)?;
     handle.attach_kernel_driver(0)?;
     Ok(())
 }
 
-pub fn wait<F: Fn(Flags) -> bool>(handle: &mut DeviceHandle, f: F, buf: &mut [u8]) -> Result<(), YubicoError>  {
+pub fn wait<F: Fn(Flags) -> bool>(handle: &mut DeviceHandle<Context>, f: F, buf: &mut [u8]) -> Result<(), YubicoError>  {
     loop {
         read(handle, buf)?;
         let flags = Flags::from_bits_truncate(buf[7]);
@@ -98,14 +98,14 @@ pub fn wait<F: Fn(Flags) -> bool>(handle: &mut DeviceHandle, f: F, buf: &mut [u8
     }
 }
 
-pub fn read(handle: &mut DeviceHandle, buf: &mut [u8]) -> Result<usize, YubicoError> {
+pub fn read(handle: &mut DeviceHandle<Context>, buf: &mut [u8]) -> Result<usize, YubicoError> {
     assert_eq!(buf.len(), 8);
     let reqtype = request_type(Direction::In, RequestType::Class, Recipient::Interface);
     let value = REPORT_TYPE_FEATURE << 8;
     Ok(handle.read_control(reqtype, HID_GET_REPORT, value, 0, buf, Duration::new(2, 0))?)
 }
 
-pub fn write_frame(handle: &mut DeviceHandle, frame: &Frame) -> Result<(), YubicoError> {
+pub fn write_frame(handle: &mut DeviceHandle<Context>, frame: &Frame) -> Result<(), YubicoError> {
     let mut data = unsafe {
         slice::from_raw_parts(frame as *const Frame as *const u8, 70)
     };
@@ -129,7 +129,7 @@ pub fn write_frame(handle: &mut DeviceHandle, frame: &Frame) -> Result<(), Yubic
     Ok(())
 }
 
-pub fn raw_write(handle: &mut DeviceHandle, packet: &[u8]) -> Result<(), YubicoError> {
+pub fn raw_write(handle: &mut DeviceHandle<Context>, packet: &[u8]) -> Result<(), YubicoError> {
     let reqtype = request_type(Direction::Out, RequestType::Class, Recipient::Interface);
     let value = REPORT_TYPE_FEATURE << 8;
     if handle.write_control(reqtype, HID_SET_REPORT, value, 0, &packet, Duration::new(2, 0))? != 8 {
@@ -140,14 +140,14 @@ pub fn raw_write(handle: &mut DeviceHandle, packet: &[u8]) -> Result<(), YubicoE
 }
 
 /// Reset the write state after a read.
-pub fn write_reset(handle: &mut DeviceHandle) -> Result<(), YubicoError> {
+pub fn write_reset(handle: &mut DeviceHandle<Context>) -> Result<(), YubicoError> {
     raw_write(handle, &[0, 0, 0, 0, 0, 0, 0, 0x8f])?;
     let mut buf = [0; 8];
     wait(handle, |x| !x.contains(Flags::SLOT_WRITE_FLAG), &mut buf)?;
     Ok(())
 }
 
-pub fn read_response(handle: &mut DeviceHandle, response:&mut [u8]) -> Result<usize, YubicoError> {
+pub fn read_response(handle: &mut DeviceHandle<Context>, response:&mut [u8]) -> Result<usize, YubicoError> {
     let mut r0 = 0;
     wait(handle, |f| {f.contains(Flags::RESP_PENDING_FLAG)}, &mut response[.. 8])?;
     r0 += 7;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -45,7 +45,7 @@ pub fn open_device(context: &mut Context, vid: u16, pid: u16) -> Result<DeviceHa
                         for usb_int in interface.descriptors() {
                             match handle.kernel_driver_active(usb_int.interface_number()) {
                                 Ok(true) => {
-                                    #[cfg(not(target_os = "macos"))]
+                                    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
                                     handle.detach_kernel_driver(usb_int.interface_number())?;
                                 },
                                 _ => continue
@@ -54,7 +54,7 @@ pub fn open_device(context: &mut Context, vid: u16, pid: u16) -> Result<DeviceHa
                             if handle.active_configuration()? != config.number() {
                                 handle.set_active_configuration(config.number())?;
                             }
-                            #[cfg(not(target_os = "macos"))]
+                            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
                             handle.claim_interface(usb_int.interface_number())?;
                         }
                     }
@@ -71,12 +71,12 @@ pub fn open_device(context: &mut Context, vid: u16, pid: u16) -> Result<DeviceHa
     Err(YubicoError::DeviceNotFound)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 pub fn close_device(_handle: DeviceHandle<Context>) -> Result<(), YubicoError> {
     Ok(())
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 pub fn close_device(mut handle: DeviceHandle<Context>) -> Result<(), YubicoError> {
     handle.release_interface(0)?;
     handle.attach_kernel_driver(0)?;

--- a/src/yubicoerror.rs
+++ b/src/yubicoerror.rs
@@ -1,6 +1,6 @@
 use std::error;
 use std::fmt;
-use libusb::Error as usbError;
+use rusb::Error as usbError;
 use std::io::Error as ioError;
 
 #[derive(Debug)]


### PR DESCRIPTION
Replace [libusb](https://crates.io/crates/libusb) with [rusb](https://crates.io/crates/rusb).

libusb crate doesn't seem to be maintained any more, rusb is the future.

Notably, rusb comes with [libusb1-sys](https://crates.io/crates/libusb1-sys), which can be easily built using msvc, [choco](https://chocolatey.org) and [Zadig](https://zadig.akeo.ie) under Windows. [Fiddling with MSYS, MinGW and x86_64-pc-windows-gnu target is just soul crushing every time lol...](https://github.com/Frederick888/git-credential-keepassxc/actions)