### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ name = "yubico_manager"
 path = "src/lib.rs"
 
 [dependencies]
-rand = "0.7"
+rand = "0.8.4"
 bitflags = "1.2"
-rusb = "0.6.5"
+rusb = "0.8.1"
 structure = "0.1"
 
 aes = "0.7.4"
-block-modes = "0.5"
-hmac = "0.8"
+block-modes = "0.8.1"
+hmac = "0.11.0"
 sha-1 = "0.9"
 
 [dev-dependencies]

--- a/examples/configuration_hmac.rs
+++ b/examples/configuration_hmac.rs
@@ -19,13 +19,13 @@ fn main() {
            .set_product_id(device.product_id)
            .set_command(Command::Configuration2);
 
-        let mut rng = thread_rng();
+        let rng = thread_rng();
 
         let require_press_button = false;
 
         // Secret must have 20 bytes
         // Used rand here, but you can set your own secret: let secret: &[u8; 20] = b"my_awesome_secret_20";
-        let secret: String = rng.sample_iter(&Alphanumeric).take(20).collect();
+        let secret: String = rng.sample_iter(&Alphanumeric).take(20).map(char::from).collect();
         let hmac_key: HmacKey = HmacKey::from_slice(secret.as_bytes());
 
         let mut device_config = DeviceModeConfig::default();

--- a/src/sec.rs
+++ b/src/sec.rs
@@ -10,7 +10,7 @@ pub const CRC_RESIDUAL_OK: u16 = 0xf0b8;
 type HmacSha1 = Hmac<Sha1>;
 
 pub fn hmac_sha1(key: &HmacKey, data: &[u8]) -> [u8; SHA1_DIGEST_SIZE] {
-    let mut hmac = HmacSha1::new_varkey(&key.0).unwrap();
+    let mut hmac = HmacSha1::new_from_slice(&key.0).unwrap();
     hmac.update(data);
     let result = hmac.finalize();
 


### PR DESCRIPTION
rand 0.7 -> 0.8.4
rusb 0.6.5 -> 0.8.1
block-modes 0.5 -> 0.8.1
hmac 0.8 -> 0.11.0

---

It seems that the outdated `vcpkg` in the dependency tree is causing issues: [1].

My build is all good now after upgrading dependencies of this package: [2].

I upgrade other dependencies apart from `rusb` as well since it wasn't of too much hassle :)

[1] https://github.com/Frederick888/git-credential-keepassxc/runs/3453581722?check_suite_focus=true
[2] https://github.com/Frederick888/git-credential-keepassxc/actions/runs/1178801889